### PR TITLE
Update chooser.py

### DIFF
--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from wagtail.admin.forms import SearchForm
+from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core.models import Page
 from wagtail.search.backends import get_search_backend


### PR DESCRIPTION
As of wagtail 2.3 wagtail.admin.forms SearchForm has be deprecated and moved to wagtail.admin.forms.search SearchForm.

If this isn't the best thing to do for backwards compatibility I would suggest checking the wagtail version before importing SearchForm.