### PR TITLE
'wagtail.contrib.wagtailroutable_page'

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -24,5 +24,5 @@ Add ``wagtailnews`` and ``wagtail.contrib.wagtailroutablepage`` to your ``INSTAL
 
   INSTALLED_APPS += [
       'wagtailnews',
-      'wagtail.contrib.wagtailroutablepage',
+      'wagtail.contrib.routable_page',
   ]


### PR DESCRIPTION
Hello, 'wagtail.contrib.wagtailroutable_page' is called 'wagtail.contrib.routable_page' now.