### PR TITLE
Compatibility with Wagtail 2.7

### DIFF
--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from django.utils.http import urlquote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
-
 import datetime
 
 from tests.app.models import NewsIndex, NewsItem

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -1,12 +1,13 @@
 # -*- coding: utf8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import datetime
+
 from django.test import TestCase
 from django.utils import timezone
 from django.utils.http import urlquote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
-import datetime
 
 from tests.app.models import NewsIndex, NewsItem
 

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django.utils.http import urlquote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
+import datetime
 
 from tests.app.models import NewsIndex, NewsItem
 
@@ -19,10 +20,11 @@ class TestNewsItem(TestCase, WagtailTestUtils):
         self.index = NewsIndex(
             title='News', slug='news')
         root_page.add_child(instance=self.index)
+        ni_date = timezone.make_aware(datetime.datetime(2017,4,13,12,0,0))
         self.newsitem = NewsItem.objects.create(
             newsindex=self.index,
             title='A post',
-            date=timezone.localtime(timezone.now()).replace(2017, 4, 13))
+            date=ni_date)
 
     def test_view(self):
         response = self.client.get(self.newsitem.url())

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django.utils.http import urlquote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
+
 import datetime
 
 from tests.app.models import NewsIndex, NewsItem

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -21,7 +21,7 @@ class TestNewsItem(TestCase, WagtailTestUtils):
         self.index = NewsIndex(
             title='News', slug='news')
         root_page.add_child(instance=self.index)
-        ni_date = timezone.make_aware(datetime.datetime(2017,4,13,12,0,0))
+        ni_date = timezone.make_aware(datetime.datetime(2017, 4, 13, 12, 0, 0))
         self.newsitem = NewsItem.objects.create(
             newsindex=self.index,
             title='A post',

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -11,7 +11,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core.models import Page
 from wagtail.search.backends import get_search_backend
-from wagtail.utils.pagination import paginate
+from wagtailnews.conf import paginate
 
 from ..models import NEWSINDEX_MODEL_CLASSES, AbstractNewsItem, NewsIndexMixin
 from ..permissions import (

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core.models import Page

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -7,7 +7,6 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core.models import Page

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -11,6 +11,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core.models import Page
 from wagtail.search.backends import get_search_backend
+
 from wagtailnews.conf import paginate
 
 from ..models import NEWSINDEX_MODEL_CLASSES, AbstractNewsItem, NewsIndexMixin

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -22,6 +22,18 @@ from ..permissions import format_perms, perms_for_template
 
 OPEN_PREVIEW_PARAM = 'do_preview'
 
+# Wagtail < 2.6 compatibility
+def bind_to_instance(self, instance, form, request):
+    return self.bind_to(instance=instance, form=form, request=request)
+def bind_to_model(self, model):
+    return self.bind_to(model=model)
+
+from wagtail.admin.edit_handlers import EditHandler
+if hasattr(EditHandler(), 'bind_to'):
+    EditHandler.bind_to_model = bind_to_model
+    EditHandler.bind_to_instance = bind_to_instance
+# Wagtail < 2.6 compatibility ends
+
 
 @lru_cache(maxsize=None)
 def get_newsitem_edit_handler(NewsItem):

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -9,7 +9,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
-
 from wagtail import VERSION
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -22,11 +22,15 @@ from ..permissions import format_perms, perms_for_template
 
 OPEN_PREVIEW_PARAM = 'do_preview'
 
+
 # Wagtail < 2.6 compatibility
 def bind_to_instance(self, instance, form, request):
     return self.bind_to(instance=instance, form=form, request=request)
+
+
 def bind_to_model(self, model):
     return self.bind_to(model=model)
+
 
 if hasattr(EditHandler(), 'bind_to'):
     EditHandler.bind_to_model = bind_to_model

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -26,11 +26,11 @@ OPEN_PREVIEW_PARAM = 'do_preview'
 @lru_cache(maxsize=None)
 def get_newsitem_edit_handler(NewsItem):
     if hasattr(NewsItem, 'edit_handler'):
-        return NewsItem.edit_handler.bind_to_model(NewsItem)
+        return NewsItem.edit_handler.bind_to(model=NewsItem)
 
     panels = extract_panel_definitions_from_model_class(
         NewsItem, exclude=['newsindex'])
-    return ObjectList(panels).bind_to_model(NewsItem)
+    return ObjectList(panels).bind_to(model=NewsItem)
 
 
 def create(request, pk):
@@ -78,11 +78,11 @@ def create(request, pk):
         form = EditForm(instance=newsitem)
 
     if VERSION >= (2, 1):
-        edit_handler = edit_handler.bind_to_instance(
+        edit_handler = edit_handler.bind_to(
             instance=newsitem, form=form, request=request
         )
     else:
-        edit_handler = edit_handler.bind_to_instance(
+        edit_handler = edit_handler.bind_to(
             instance=newsitem, form=form
         )
 
@@ -141,11 +141,11 @@ def edit(request, pk, newsitem_pk):
         do_preview = bool(request.GET.get(OPEN_PREVIEW_PARAM))
 
     if VERSION >= (2, 1):
-        edit_handler = edit_handler.bind_to_instance(
+        edit_handler = edit_handler.bind_to(
             instance=newsitem, form=form, request=request
         )
     else:
-        edit_handler = edit_handler.bind_to_instance(
+        edit_handler = edit_handler.bind_to(
             instance=newsitem, form=form
         )
 

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -26,11 +26,11 @@ OPEN_PREVIEW_PARAM = 'do_preview'
 @lru_cache(maxsize=None)
 def get_newsitem_edit_handler(NewsItem):
     if hasattr(NewsItem, 'edit_handler'):
-        return NewsItem.edit_handler.bind_to(model=NewsItem)
+        return NewsItem.edit_handler.bind_to_model(NewsItem)
 
     panels = extract_panel_definitions_from_model_class(
         NewsItem, exclude=['newsindex'])
-    return ObjectList(panels).bind_to(model=NewsItem)
+    return ObjectList(panels).bind_to_model(NewsItem)
 
 
 def create(request, pk):
@@ -78,11 +78,11 @@ def create(request, pk):
         form = EditForm(instance=newsitem)
 
     if VERSION >= (2, 1):
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.bind_to_instance(
             instance=newsitem, form=form, request=request
         )
     else:
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.bind_to_instance(
             instance=newsitem, form=form
         )
 
@@ -141,11 +141,11 @@ def edit(request, pk, newsitem_pk):
         do_preview = bool(request.GET.get(OPEN_PREVIEW_PARAM))
 
     if VERSION >= (2, 1):
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.bind_to_instance(
             instance=newsitem, form=form, request=request
         )
     else:
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.bind_to_instance(
             instance=newsitem, form=form
         )
 

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -9,10 +9,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
+
 from wagtail import VERSION
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (
-    ObjectList, extract_panel_definitions_from_model_class)
+    EditHandler, ObjectList, extract_panel_definitions_from_model_class)
 from wagtail.core.models import Page
 
 from .. import signals
@@ -28,7 +29,6 @@ def bind_to_instance(self, instance, form, request):
 def bind_to_model(self, model):
     return self.bind_to(model=model)
 
-from wagtail.admin.edit_handlers import EditHandler
 if hasattr(EditHandler(), 'bind_to'):
     EditHandler.bind_to_model = bind_to_model
     EditHandler.bind_to_instance = bind_to_instance

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
django.contrib.staticfiles.templatetags.staticfiles.static was deprecated
wagtail.utils.pagination.paginate was deprecated
bind_to_model and bind_to_instance were deprecated