### PR TITLE
Change 'lru_cache' import for django 3.0+ compatibility

### DIFF
--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from io import StringIO
 from urllib.parse import urlparse
 
@@ -7,7 +8,6 @@ from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 from wagtail import VERSION
 from wagtail.admin import messages


### PR DESCRIPTION
django.utils.lru_cache.lru_cache() was removed in django 3.0, see: https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis