### PR TITLE
Update settings.py for modern Django and Wagtail use

### DIFF
--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
 ]
@@ -60,8 +61,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-    'wagtail.core.middleware.SiteMiddleware',
 ]
 
 TEMPLATES = [


### PR DESCRIPTION
The SiteMiddleware has been deprecated and seems unused here. `django.contrib.admin` requires the `django.contrib.messages`. With both changes, the tests pass with Django 2.2.13 and Wagtail 2.10.