### PR TITLE
Set page_key to "page" in pagination of index

### DIFF
--- a/wagtailnews/templates/wagtailnews/index.html
+++ b/wagtailnews/templates/wagtailnews/index.html
@@ -41,7 +41,7 @@
 
     {% if newsitem_list %}
         {% include "wagtailnews/newsitem_list.html" %}
-        {% paginate page %}
+        {% paginate page page_key="page" %}
     {% else %}
         <div class="nice-padding">No news posts yet!</div>
     {% endif %}


### PR DESCRIPTION
Wagtail admin templatetag {% paginate %} defaults page key to "p", whereas wagtailnews uses "page". 

Without setting the page_key the pagination would not work, because generated querystrings would point to a specific page using ?p=... and wagtailnews would look for ?page=...