### PR TITLE
Support for Wagtail 2.15 and 2.16 and Django >= 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .tox/
 settings.py
 build/
+venv/

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,4 +2,4 @@ Tim Heap <tim@takeflight.com.au>
 Liam Brenner <liam@takeflight.com.au>
 Eloise Ducky Macdonald-Meyer <eloise@takeflight.com.au>
 Danielle Madeley <danielle@madeley.id.au>
-
+Taylor Richberger <taywee@gmx.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,5 @@ Liam Brenner <liam@takeflight.com.au>
 Eloise Ducky Macdonald-Meyer <eloise@takeflight.com.au>
 Danielle Madeley <danielle@madeley.id.au>
 Taylor Richberger <taywee@gmx.com>
+Jordan Markov <@jordanmarkov>
+Seb Brown <seb@takeflight.com.au>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Danielle Madeley <danielle@madeley.id.au>
 Taylor Richberger <taywee@gmx.com>
 Jordan Markov <@jordanmarkov>
 Seb Brown <seb@takeflight.com.au>
+Rense VanderHoek <rense@me.com>

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 wagtailnews
 ===========
 
-A plugin for Wagtail that provides news / blogging functionality.
+A plugin for Wagtail that provides a simple news functionality.
 
 Installing
 ==========
@@ -11,7 +11,13 @@ Install using pip::
 
     pip install wagtailnews
 
-It works with Wagtail 2.3 and upwards. For older versions of Wagtail see past releases.
+``wagtailnews`` 2.x is compatible with Wagtail 2.15 or 2.16,
+Django 3.0 and higher,
+and Python 3.6 and higher.
+
+For older version of Wagtail or Django, see past releases
+
+For wagtail 3 and 4 check wagtailnews 3 and higher.
 
 Documentation
 =============
@@ -20,6 +26,21 @@ Documentation
 
 Quick start
 ===========
+
+Install ``wagtailnews`` using pip::
+
+   pip install wagtailnews
+
+Step 2
+______
+
+Add ``wagtailnews`` to your ``INSTALLED_APPS`` in settings:
+
+.. code-block:: python
+
+  INSTALLED_APPS += [
+      'wagtailnews',
+  ]
 
 Create news models for your application that inherit from the relevant ``wagtailnews`` models:
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -4,11 +4,13 @@
 Setup
 =====
 
-``wagtailnews`` is compatible with Wagtail 2.3 and higher,
-Django 1.11 and higher,
-and Python 3.4 and higher.
+``wagtailnews`` 2.x is compatible with Wagtail 2.15 or 2.16,
+Django 3.0 and higher,
+and Python 3.6 and higher.
 
 For older version of Wagtail or Django, see past releases
+
+For wagtail 3 and 4 check wagtailnews 3 and higher.
 
 Step 1
 ______
@@ -20,11 +22,10 @@ Install ``wagtailnews`` using pip::
 Step 2
 ______
 
-Add ``wagtailnews`` and ``wagtail.contrib.routable_page`` to your ``INSTALLED_APPS`` in settings:
+Add ``wagtailnews`` to your ``INSTALLED_APPS`` in settings:
 
 .. code-block:: python
 
   INSTALLED_APPS += [
       'wagtailnews',
-      'wagtail.contrib.routable_page',
   ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     url='https://github.com/takeflight/wagtailnews/',
 
     install_requires=[
-        'wagtail>=2.3.0',
+        'wagtail>=2.16,<3',
+        'django>=3,<4'
     ],
     extras_require={
         'docs': documentation_extras

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=[
         'wagtail>=2.16,<3',
-        'django>=3,<4'
+        'django>=3'
     ],
     extras_require={
         'docs': documentation_extras

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     url='https://github.com/takeflight/wagtailnews/',
 
     install_requires=[
-        'wagtail>=2.16,<3',
+        'wagtail>=2.15,<3',
         'django>=3'
     ],
     extras_require={

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
@@ -42,7 +41,6 @@ class NewsIndex(NewsIndexMixin, Page):
         return context
 
 
-@python_2_unicode_compatible
 class NewsItem(AbstractNewsItem):
     title = models.CharField(max_length=32)
     page = models.ForeignKey(

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -51,6 +51,12 @@ DATABASES = {
 
 WAGTAIL_SITE_NAME = 'Wagtail News'
 
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.search.backends.database',
+    }
+}
+
 DEBUG = True
 
 USE_TZ = True

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -34,6 +34,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 ]
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 ALLOWED_HOSTS = ['localhost']
 
 SECRET_KEY = 'not a secret'

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'', include(wagtail_urls)),
 ]

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -5,7 +5,7 @@ import datetime
 
 from django.test import TestCase
 from django.utils import timezone
-from django.utils.http import urlquote
+from urllib.parse import quote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -51,7 +51,7 @@ class TestNewsItem(TestCase, WagtailTestUtils):
 
         self.assertEqual(
             self.newsitem.url(),
-            urlquote('/news/2017/4/13/{}-a-post/'.format(self.newsitem.pk)))
+            quote('/news/2017/4/13/{}-a-post/'.format(self.newsitem.pk)))
         self.assertEqual(
             response.redirect_chain,
             [(self.newsitem.url(), 301)])
@@ -66,7 +66,7 @@ class TestNewsItem(TestCase, WagtailTestUtils):
 
         self.assertEqual(
             self.newsitem.url(),
-            urlquote('/news/2017/4/13/{}-你好世界/'.format(self.newsitem.pk)))
+            quote('/news/2017/4/13/{}-你好世界/'.format(self.newsitem.pk)))
         self.assertEqual(
             response.redirect_chain,
             [(self.newsitem.url(), 301)])

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -8,6 +8,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem, SecondaryNewsIndex
 
+UNAUTHORIZED=302
 
 def p(permission_string):
     app_label, codename = permission_string.split('.', 1)
@@ -56,7 +57,7 @@ class PermissionTestCase(TestCase, WagtailTestUtils):
             permission_type='add')
 
         self.user = self.create_test_user()
-        self.client.login(username='test@email.com', password='password')
+        self.client.force_login(self.user)
 
     def create_test_user(self):
         """
@@ -123,7 +124,7 @@ class TestChooseNewsIndex(PermissionTestCase):
             title='Secondary News', slug='secondary-news'))
 
         response = self.client.get(reverse('wagtailnews:choose'))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_chooser_has_perms_no_news(self):
@@ -152,7 +153,7 @@ class TestNewsIndex(WithNewsIndexTestCase, PermissionTestCase):
         """
         Check the user is denied access to the news index list
         """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
 
 class TestCreateNewsItem(WithNewsIndexTestCase, PermissionTestCase):
@@ -169,16 +170,16 @@ class TestCreateNewsItem(WithNewsIndexTestCase, PermissionTestCase):
     @grant_permissions(['app.add_newsitem'])
     def test_only_add_perm(self):
         """ Users need both add and edit. Add is not sufficient """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_only_edit_perm(self):
         """ Users need both add and edit. Edit is not sufficient """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     def test_no_permission(self):
         """ Test user can not create without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_add_button_appears(self):
@@ -209,7 +210,7 @@ class TestEditNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not edit without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_edit_button_appears(self):
@@ -240,7 +241,7 @@ class TestUnpublishNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not unpublish without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_unpublish_button_appears(self):
@@ -271,7 +272,7 @@ class TestDeleteNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not delete without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.delete_newsitem'])
     def test_delete_button_appears_index(self):
@@ -313,7 +314,7 @@ class TestSearchNewsItem(WithNewsItemTestCase, PermissionTestCase):
         self.assertStatusCode(self.url, 200)
 
     def test_no_permission(self):
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_search_area_appears_permission(self):

--- a/wagtailnews/edit_handlers.py
+++ b/wagtailnews/edit_handlers.py
@@ -1,5 +1,11 @@
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+
+import django
+if django.VERSION >= (4, 0):
+  from django.utils.encoding import force_str
+else:
+  from django.utils.encoding import force_text as force_str
+
 from django.utils.safestring import mark_safe
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
@@ -49,4 +55,4 @@ class NewsChooserPanel(BaseChooserPanel):
         }))
 
     def get_newsitem_type_name(self):
-        return force_text(self.target_model()._meta.verbose_name)
+        return force_str(self.target_model()._meta.verbose_name)

--- a/wagtailnews/menu.py
+++ b/wagtailnews/menu.py
@@ -1,5 +1,5 @@
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.menu import MenuItem
 
 from .permissions import user_can_edit_news

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -11,7 +11,7 @@ from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.http import urlquote
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -9,7 +9,13 @@ from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils import timezone
-from django.utils.http import urlquote
+
+import django
+if django.VERSION >= (4, 0):
+  from urllib.parse import quote
+else: # Support for Django 3.x
+  from django.utils.http import urlquote as quote
+
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
@@ -116,7 +122,7 @@ class NewsIndexMixin(RoutablePageMixin):
         # Check the URL date and slug are still correct
         newsitem_url = newsitem.url
         newsitem_path = urlparse(newsitem_url, allow_fragments=True).path
-        if urlquote(request.path) != newsitem_path:
+        if quote(request.path) != newsitem_path:
             return HttpResponsePermanentRedirect(newsitem_url)
 
         # Get the newsitem to serve itself

--- a/wagtailnews/signals.py
+++ b/wagtailnews/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-newsitem_published = Signal(providing_args=['instance', 'created'])
-newsitem_unpublished = Signal(providing_args=['instance'])
-newsitem_draft_saved = Signal(providing_args=['instance', 'created'])
-newsitem_deleted = Signal(providing_args=['instance'])
+newsitem_published = Signal() # instance, created
+newsitem_unpublished = Signal() # instance
+newsitem_draft_saved = Signal() # instance, created
+newsitem_deleted = Signal() # instance

--- a/wagtailnews/templatetags/wagtailnews_admin_tags.py
+++ b/wagtailnews/templatetags/wagtailnews_admin_tags.py
@@ -1,7 +1,7 @@
 from django.template.library import Library
 from django.urls import reverse
 from django.utils.html import format_html, mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 register = Library()
 

--- a/wagtailnews/urls.py
+++ b/wagtailnews/urls.py
@@ -1,26 +1,26 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import chooser, editor
 
 app_name = 'wagtailnews'
 urlpatterns = [
-    url(r'^$', chooser.choose,
+    re_path(r'^$', chooser.choose,
         name='choose'),
-    url(r'^search/$', chooser.search,
+    re_path(r'^search/$', chooser.search,
         name='search'),
-    url(r'^(?P<pk>\d+)/$', chooser.index,
+    re_path(r'^(?P<pk>\d+)/$', chooser.index,
         name='index'),
-    url(r'^(?P<pk>\d+)/create/$', editor.create,
+    re_path(r'^(?P<pk>\d+)/create/$', editor.create,
         name='create'),
-    url(r'^(?P<pk>\d+)/edit/(?P<newsitem_pk>.*)/$', editor.edit,
+    re_path(r'^(?P<pk>\d+)/edit/(?P<newsitem_pk>.*)/$', editor.edit,
         name='edit'),
-    url(r'^(?P<pk>\d+)/unpublish/(?P<newsitem_pk>.*)/$', editor.unpublish,
+    re_path(r'^(?P<pk>\d+)/unpublish/(?P<newsitem_pk>.*)/$', editor.unpublish,
         name='unpublish'),
-    url(r'^(?P<pk>\d+)/delete/(?P<newsitem_pk>.*)/$', editor.delete,
+    re_path(r'^(?P<pk>\d+)/delete/(?P<newsitem_pk>.*)/$', editor.delete,
         name='delete'),
-    url(r'^(?P<pk>\d+)/view_draft/(?P<newsitem_pk>.*)/$', editor.view_draft,
+    re_path(r'^(?P<pk>\d+)/view_draft/(?P<newsitem_pk>.*)/$', editor.view_draft,
         name='view_draft'),
     # Choosers
-    url(r'^chooser/$', chooser.choose_modal, name='chooser'),
-    url(r'^chooser/(?P<pk>\d+)/(?P<newsitem_pk>\d+)/$', chooser.chosen_modal, name='chosen'),
+    re_path(r'^chooser/$', chooser.choose_modal, name='chooser'),
+    re_path(r'^chooser/(?P<pk>\d+)/(?P<newsitem_pk>\d+)/$', chooser.chosen_modal, name='chosen'),
 ]

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 1, 1)
+version_info = (2, 1, 2)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 7, 0)
+version_info = (2, 7, 1)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 1, 0)
+version_info = (2, 1, 1)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 18, 1)
+version_info = (2, 1, 0)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 17, 0)
+version_info = (0, 18, 0)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 7, 1)
+version_info = (2, 7, 2)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 3, 0)
+version_info = (2, 7, 0)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/version.py
+++ b/wagtailnews/version.py
@@ -1,2 +1,2 @@
-version_info = (0, 18, 0)
+version_info = (0, 18, 1)
 version = '.'.join(map(str, version_info))

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -259,7 +259,10 @@ def build_dummy_request(newsitem):
     handler = BaseHandler()
     handler.load_middleware()
     # call each middleware in turn and throw away any responses that they might return
-    for middleware_method in handler._request_middleware:
-        middleware_method(request)
+    if hasattr(handler, '_request_middleware'):
+        for middleware_method in handler._request_middleware:
+            middleware_method(request)
+    else:
+        handler.get_response(request)
 
     return request

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -8,7 +8,7 @@ from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail import VERSION
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
-from django.urls import reverse
+from django.urls import reverse, re_path
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.search import SearchArea
@@ -17,7 +17,7 @@ from .permissions import user_can_edit_news
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^news/', include(urls)),
+        re_path(r'^news/', include(urls)),
     ]
 
 

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.search import SearchArea
 from wagtail.core import hooks
 

--- a/wagtailnews/widgets.py
+++ b/wagtailnews/widgets.py
@@ -1,7 +1,7 @@
 import json
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.widgets import AdminChooser
 
 


### PR DESCRIPTION
Bring wagtailnews 2.x version up par with Wagtail < 3 (namely 2.15 and 2.16) and Django >= 3.

This PR will fix all the deprecation warnings and is tested to work with Django 3 and 4. Wagtail must be kept under 3 because the templates change so much in 3. I would suggest wagtailnews 2.x to support Wagtail 2 and introduce wagtailnews version 3 which would require Wagtail 3 and bigger. I will post a different PR for those changes, later.

This PR does not contain any new features.