### PR TITLE
Support for Wagtail 3 and 4 and Django >= 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     url='https://github.com/takeflight/wagtailnews/',
 
     install_requires=[
-        'wagtail>=2.16,<3',
-        'django>=3'
+        'wagtail>=2.15,<4',
+        'django>=3,<4.1'
     ],
     extras_require={
         'docs': documentation_extras

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     url='https://github.com/takeflight/wagtailnews/',
 
     install_requires=[
-        'wagtail>=2.3.0',
+        'wagtail>=2.16,<3',
+        'django>=3,<4'
     ],
     extras_require={
         'docs': documentation_extras

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     url='https://github.com/takeflight/wagtailnews/',
 
     install_requires=[
-        'wagtail>=2.15,<4',
-        'django>=3,<4.1'
+        'wagtail>=3.0',
+        'django>=3.2'
     ],
     extras_require={
         'docs': documentation_extras

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=[
         'wagtail>=2.16,<3',
-        'django>=3,<4'
+        'django>=3'
     ],
     extras_require={
         'docs': documentation_extras

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -2,9 +2,17 @@ from django.db import models
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
-from wagtail.admin.edit_handlers import (
-    FieldPanel, ObjectList, PageChooserPanel, TabbedInterface)
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+  from wagtail.admin.panels import (
+      FieldPanel, ObjectList, PageChooserPanel, TabbedInterface)
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+  from wagtail.admin.edit_handlers import (
+      FieldPanel, ObjectList, PageChooserPanel, TabbedInterface)
+
 from wagtail.search import index
 
 from wagtailnews.decorators import newsindex

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
@@ -42,7 +41,6 @@ class NewsIndex(NewsIndexMixin, Page):
         return context
 
 
-@python_2_unicode_compatible
 class NewsItem(AbstractNewsItem):
     title = models.CharField(max_length=32)
     page = models.ForeignKey(

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -51,6 +51,12 @@ DATABASES = {
 
 WAGTAIL_SITE_NAME = 'Wagtail News'
 
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.search.backends.database',
+    }
+}
+
 DEBUG = True
 
 USE_TZ = True

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -34,6 +34,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 ]
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 ALLOWED_HOSTS = ['localhost']
 
 SECRET_KEY = 'not a secret'

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -50,6 +50,7 @@ DATABASES = {
 }
 
 WAGTAIL_SITE_NAME = 'Wagtail News'
+WAGTAILADMIN_BASE_URL = '/admin'
 
 WAGTAILSEARCH_BACKENDS = {
     'default': {

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    re_path(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'', include(wagtail_urls)),
 ]

--- a/tests/app/urls.py
+++ b/tests/app/urls.py
@@ -1,6 +1,11 @@
 from django.urls import include, re_path
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail import urls as wagtail_urls
+else: # Support for wagtail <= 4.1
+  from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
     re_path(r'^admin/', include(wagtailadmin_urls)),

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,6 +1,12 @@
 from django.test import TestCase
 from django.urls import reverse
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, SecondaryNewsIndex

--- a/tests/test_editing.py
+++ b/tests/test_editing.py
@@ -2,7 +2,13 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 from django.urls import reverse
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem, SecondaryNewsIndex

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -2,7 +2,13 @@ import datetime
 
 from django.test import TestCase
 from django.utils import timezone
-from wagtail.core.models import Site
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page, Site
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page, Site
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem

--- a/tests/test_newsindex.py
+++ b/tests/test_newsindex.py
@@ -3,7 +3,13 @@ import datetime
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils import timezone
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import (

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -5,7 +5,7 @@ import datetime
 
 from django.test import TestCase
 from django.utils import timezone
-from django.utils.http import urlquote
+from urllib.parse import quote
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -51,7 +51,7 @@ class TestNewsItem(TestCase, WagtailTestUtils):
 
         self.assertEqual(
             self.newsitem.url(),
-            urlquote('/news/2017/4/13/{}-a-post/'.format(self.newsitem.pk)))
+            quote('/news/2017/4/13/{}-a-post/'.format(self.newsitem.pk)))
         self.assertEqual(
             response.redirect_chain,
             [(self.newsitem.url(), 301)])
@@ -66,7 +66,7 @@ class TestNewsItem(TestCase, WagtailTestUtils):
 
         self.assertEqual(
             self.newsitem.url(),
-            urlquote('/news/2017/4/13/{}-你好世界/'.format(self.newsitem.pk)))
+            quote('/news/2017/4/13/{}-你好世界/'.format(self.newsitem.pk)))
         self.assertEqual(
             response.redirect_chain,
             [(self.newsitem.url(), 301)])

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -6,7 +6,13 @@ import datetime
 from django.test import TestCase
 from django.utils import timezone
 from urllib.parse import quote
-from wagtail.core.models import Site
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page, Site
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page, Site
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,7 +3,13 @@ from functools import wraps
 from django.contrib.auth.models import Group, Permission, User
 from django.test import TestCase
 from django.urls import reverse
-from wagtail.core.models import GroupPagePermission, Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page, GroupPagePermission
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page, GroupPagePermission
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem, SecondaryNewsIndex

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -8,6 +8,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem, SecondaryNewsIndex
 
+UNAUTHORIZED=302
 
 def p(permission_string):
     app_label, codename = permission_string.split('.', 1)
@@ -56,7 +57,7 @@ class PermissionTestCase(TestCase, WagtailTestUtils):
             permission_type='add')
 
         self.user = self.create_test_user()
-        self.client.login(username='test@email.com', password='password')
+        self.client.force_login(self.user)
 
     def create_test_user(self):
         """
@@ -123,7 +124,7 @@ class TestChooseNewsIndex(PermissionTestCase):
             title='Secondary News', slug='secondary-news'))
 
         response = self.client.get(reverse('wagtailnews:choose'))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_chooser_has_perms_no_news(self):
@@ -152,7 +153,7 @@ class TestNewsIndex(WithNewsIndexTestCase, PermissionTestCase):
         """
         Check the user is denied access to the news index list
         """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
 
 class TestCreateNewsItem(WithNewsIndexTestCase, PermissionTestCase):
@@ -169,16 +170,16 @@ class TestCreateNewsItem(WithNewsIndexTestCase, PermissionTestCase):
     @grant_permissions(['app.add_newsitem'])
     def test_only_add_perm(self):
         """ Users need both add and edit. Add is not sufficient """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_only_edit_perm(self):
         """ Users need both add and edit. Edit is not sufficient """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     def test_no_permission(self):
         """ Test user can not create without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_add_button_appears(self):
@@ -209,7 +210,7 @@ class TestEditNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not edit without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_edit_button_appears(self):
@@ -240,7 +241,7 @@ class TestUnpublishNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not unpublish without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.change_newsitem'])
     def test_unpublish_button_appears(self):
@@ -271,7 +272,7 @@ class TestDeleteNewsItem(WithNewsItemTestCase, PermissionTestCase):
 
     def test_no_permission(self):
         """ Test user can not delete without permission """
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.delete_newsitem'])
     def test_delete_button_appears_index(self):
@@ -313,7 +314,7 @@ class TestSearchNewsItem(WithNewsItemTestCase, PermissionTestCase):
         self.assertStatusCode(self.url, 200)
 
     def test_no_permission(self):
-        self.assertStatusCode(self.url, 403)
+        self.assertStatusCode(self.url, UNAUTHORIZED)
 
     @grant_permissions(['app.add_newsitem', 'app.change_newsitem'])
     def test_search_area_appears_permission(self):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,7 +1,13 @@
 from django.test import TestCase
 from django.urls import reverse
 from taggit.models import Tag
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,7 +3,13 @@ import datetime
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.utils import timezone
-from wagtail.core.models import Page, Site
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page, Site
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page, Site
+
 from wagtail.tests.utils import WagtailTestUtils
 
 from tests.app.models import NewsIndex, NewsItem

--- a/wagtailnews/blocks.py
+++ b/wagtailnews/blocks.py
@@ -1,6 +1,12 @@
 from django.utils.functional import cached_property
-from wagtail.core.blocks import ChooserBlock
-from wagtail.core.utils import resolve_model_string
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.blocks import ChooserBlock
+  from wagtail.coreutils import resolve_model_string
+else: # Support for wagtail <= 4.1
+  from wagtail.core.blocks import ChooserBlock
+  from wagtail.core.utils import resolve_model_string
 
 
 class NewsChooserBlock(ChooserBlock):

--- a/wagtailnews/edit_handlers.py
+++ b/wagtailnews/edit_handlers.py
@@ -9,7 +9,9 @@ else:
 from django.utils.safestring import mark_safe
 
 import wagtail
-if wagtail.VERSION >= (3, 0):
+if wagtail.VERSION >= (4, 2):
+  from wagtail.admin.panels import FieldPanel
+elif wagtail.VERSION >= (3, 0):
   from wagtail.admin.edit_handlers import FieldPanel
 else:
   from wagtail.admin.edit_handlers import BaseChooserPanel as FieldPanel

--- a/wagtailnews/edit_handlers.py
+++ b/wagtailnews/edit_handlers.py
@@ -7,12 +7,17 @@ else:
   from django.utils.encoding import force_text as force_str
 
 from django.utils.safestring import mark_safe
-from wagtail.admin.edit_handlers import BaseChooserPanel
+
+import wagtail
+if wagtail.VERSION >= (3, 0):
+  from wagtail.admin.edit_handlers import FieldPanel
+else:
+  from wagtail.admin.edit_handlers import BaseChooserPanel as FieldPanel
 
 from .widgets import AdminNewsChooser
 
 
-class NewsChooserPanel(BaseChooserPanel):
+class NewsChooserPanel(FieldPanel):
     """
     An edit handler for editors to pick a news item.
     Takes the field name as the only argument.

--- a/wagtailnews/edit_handlers.py
+++ b/wagtailnews/edit_handlers.py
@@ -1,5 +1,11 @@
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+
+import django
+if django.VERSION >= (4, 0):
+  from django.utils.encoding import force_str
+else:
+  from django.utils.encoding import force_text as force_str
+
 from django.utils.safestring import mark_safe
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
@@ -49,4 +55,4 @@ class NewsChooserPanel(BaseChooserPanel):
         }))
 
     def get_newsitem_type_name(self):
-        return force_text(self.target_model()._meta.verbose_name)
+        return force_str(self.target_model()._meta.verbose_name)

--- a/wagtailnews/menu.py
+++ b/wagtailnews/menu.py
@@ -1,5 +1,5 @@
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.menu import MenuItem
 
 from .permissions import user_can_edit_news

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -19,10 +19,18 @@ else: # Support for Django 3.x
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
-from wagtail.admin.edit_handlers import FieldPanel
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.admin.panels import FieldPanel
+  from wagtail.models import Page
+  from wagtail.coreutils import resolve_model_string
+else: # Support for wagtail <= 4.1
+  from wagtail.admin.edit_handlers import FieldPanel
+  from wagtail.core.models import Page
+  from wagtail.core.utils import resolve_model_string
+
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
-from wagtail.core.models import Page
-from wagtail.core.utils import resolve_model_string
 from wagtail.search import index
 
 from . import feeds

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -11,7 +11,7 @@ from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.http import urlquote
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -9,7 +9,13 @@ from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.utils import timezone
-from django.utils.http import urlquote
+
+import django
+if django.VERSION >= (4, 0):
+  from urllib.parse import quote
+else: # Support for Django 3.x
+  from django.utils.http import urlquote as quote
+
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
@@ -116,7 +122,7 @@ class NewsIndexMixin(RoutablePageMixin):
         # Check the URL date and slug are still correct
         newsitem_url = newsitem.url
         newsitem_path = urlparse(newsitem_url, allow_fragments=True).path
-        if urlquote(request.path) != newsitem_path:
+        if quote(request.path) != newsitem_path:
             return HttpResponsePermanentRedirect(newsitem_url)
 
         # Get the newsitem to serve itself

--- a/wagtailnews/signals.py
+++ b/wagtailnews/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-newsitem_published = Signal(providing_args=['instance', 'created'])
-newsitem_unpublished = Signal(providing_args=['instance'])
-newsitem_draft_saved = Signal(providing_args=['instance', 'created'])
-newsitem_deleted = Signal(providing_args=['instance'])
+newsitem_published = Signal() # instance, created
+newsitem_unpublished = Signal() # instance
+newsitem_draft_saved = Signal() # instance, created
+newsitem_deleted = Signal() # instance

--- a/wagtailnews/templates/wagtailnews/create.html
+++ b/wagtailnews/templates/wagtailnews/create.html
@@ -1,17 +1,22 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with type=newsitem_opts.verbose_name %}Creating {{ type }}{% endblocktrans %}{% endblock %}
 
+{% block extra_css %}
+    {{ block.super }}
+    {{ edit_handler.form.media.css }}
+    {{ media.css }}
+{% endblock %}
+
 {% block bodyclass %}menu-news{% endblock %}
 
-{% block content %}
-    {% trans "New" as new_str %}
-    {% trans "news post" as newspost_str %}
+{% block header %}
+  {% trans "New" as new_str %}
+  {% trans "news post" as newspost_str %}
+  {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newspost_str icon="news" merged=1 %}
+{% endblock %}
 
-    {% block header %}
-      {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newspost_str icon="news" merged=True %}
-    {% endblock %}
-
+{% block main_content %}
     <form action="{% block form_action %}{% url 'wagtailnews:create' pk=newsindex.pk %}{% endblock %}" method="POST">
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
@@ -38,11 +43,6 @@
     </form>
 {% endblock %}
 
-{% block extra_css %}
-    {% include "wagtailadmin/pages/_editor_css.html" %}
-    {{ edit_handler.form.media.css }}
-    {{ view.media.css }}
-{% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}

--- a/wagtailnews/templates/wagtailnews/delete.html
+++ b/wagtailnews/templates/wagtailnews/delete.html
@@ -1,13 +1,20 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with newsitem=newsitem %}Delete {{ newsitem }}{% endblocktrans %}{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+{% endblock %}
+
 {% block bodyclass %}menu-news{% endblock %}
-{% block content %}
 
-    {% trans "Delete" as new_str %}
-    {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newsitem icon="grip" %}
+{% block header %}
+  {% trans "Delete" as new_str %}
+  {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newsitem icon="grip" %}
+{% endblock %}
 
-    <div class="row row-flush nice-padding">
+{% block main_content %}
+    <div class="row row-flush">
         <form action="{% url 'wagtailnews:delete' pk=newsindex.pk newsitem_pk=newsitem.pk %}" method="POST">
             {% csrf_token %}
             <p>{% blocktrans %}Are you sure you want to delete this news item?{% endblocktrans %}</p>
@@ -24,9 +31,6 @@
     </div>
 {% endblock %}
 
-{% block extra_css %}
-    {% include "wagtailadmin/pages/_editor_css.html" %}
-{% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtailnews/templates/wagtailnews/edit.html
+++ b/wagtailnews/templates/wagtailnews/edit.html
@@ -2,9 +2,10 @@
 {% load i18n %}
 
 {% block titletag %}{% blocktrans with newsitem=newsitem type=newsitem_opts.verbose_name %}Editing {{ type }}: {{ newsitem }}{% endblocktrans %}{% endblock %}
-{% trans "Edit" as new_str %}
+
 {% block header %}
-  {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newsitem icon="news" merged=True %}
+  {% trans "Edit" as new_str %}
+  {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newsitem.title icon="news" merged=1 %}
 {% endblock %}
 
 {% block form_action %}{% url 'wagtailnews:edit' pk=newsindex.pk newsitem_pk=newsitem.pk %}{% endblock %}

--- a/wagtailnews/templates/wagtailnews/index.html
+++ b/wagtailnews/templates/wagtailnews/index.html
@@ -5,10 +5,14 @@
 {% block bodyclass %}menu-news{% endblock %}
 {% block content %}
 
-    <header class="nice-padding merged">
+   {% block header %}
+        {% trans "News" as news_str %}
+        {% include "wagtailadmin/shared/header.html" with title=news_str subtitle=newsindex.url icon="grip" merged=1 %}
+    {% endblock %}
+
+    <header class="nice-padding">
         <div class="row row-flush">
             <div class="left">
-                <h1 class="col icon icon-grip">{% blocktrans %}News{% endblocktrans %} <span>{{ newsindex.url }}</span></h1>
                 <form class="col search-form" action="" method="GET">
                     <ul class="fields">
                         <li class="required">

--- a/wagtailnews/templates/wagtailnews/unpublish.html
+++ b/wagtailnews/templates/wagtailnews/unpublish.html
@@ -1,13 +1,19 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load i18n %}
 {% block titletag %}{% blocktrans with newsitem=newsitem %}Unpublish {{ newsitem }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-news{% endblock %}
-{% block content %}
 
+{% block extra_css %}
+    {{ block.super }}
+{% endblock %}
+
+{% block header %}
     {% trans "Unpublish" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=newsitem icon="grip" %}
+{% endblock %}
 
-    <div class="row row-flush nice-padding">
+{% block main_content %}
+    <div class="row row-flush">
         <form action="{% url 'wagtailnews:unpublish' pk=newsindex.pk newsitem_pk=newsitem.pk %}" method="POST">
             {% csrf_token %}
             <p>{% blocktrans %}Are you sure you want to unpublish this news item?{% endblocktrans %}</p>
@@ -16,9 +22,6 @@
     </div>
 {% endblock %}
 
-{% block extra_css %}
-    {% include "wagtailadmin/pages/_editor_css.html" %}
-{% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 {% endblock %}

--- a/wagtailnews/templatetags/wagtailnews_admin_tags.py
+++ b/wagtailnews/templatetags/wagtailnews_admin_tags.py
@@ -1,7 +1,7 @@
 from django.template.library import Library
 from django.urls import reverse
 from django.utils.html import format_html, mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 register = Library()
 

--- a/wagtailnews/urls.py
+++ b/wagtailnews/urls.py
@@ -1,26 +1,26 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import chooser, editor
 
 app_name = 'wagtailnews'
 urlpatterns = [
-    url(r'^$', chooser.choose,
+    re_path(r'^$', chooser.choose,
         name='choose'),
-    url(r'^search/$', chooser.search,
+    re_path(r'^search/$', chooser.search,
         name='search'),
-    url(r'^(?P<pk>\d+)/$', chooser.index,
+    re_path(r'^(?P<pk>\d+)/$', chooser.index,
         name='index'),
-    url(r'^(?P<pk>\d+)/create/$', editor.create,
+    re_path(r'^(?P<pk>\d+)/create/$', editor.create,
         name='create'),
-    url(r'^(?P<pk>\d+)/edit/(?P<newsitem_pk>.*)/$', editor.edit,
+    re_path(r'^(?P<pk>\d+)/edit/(?P<newsitem_pk>.*)/$', editor.edit,
         name='edit'),
-    url(r'^(?P<pk>\d+)/unpublish/(?P<newsitem_pk>.*)/$', editor.unpublish,
+    re_path(r'^(?P<pk>\d+)/unpublish/(?P<newsitem_pk>.*)/$', editor.unpublish,
         name='unpublish'),
-    url(r'^(?P<pk>\d+)/delete/(?P<newsitem_pk>.*)/$', editor.delete,
+    re_path(r'^(?P<pk>\d+)/delete/(?P<newsitem_pk>.*)/$', editor.delete,
         name='delete'),
-    url(r'^(?P<pk>\d+)/view_draft/(?P<newsitem_pk>.*)/$', editor.view_draft,
+    re_path(r'^(?P<pk>\d+)/view_draft/(?P<newsitem_pk>.*)/$', editor.view_draft,
         name='view_draft'),
     # Choosers
-    url(r'^chooser/$', chooser.choose_modal, name='chooser'),
-    url(r'^chooser/(?P<pk>\d+)/(?P<newsitem_pk>\d+)/$', chooser.chosen_modal, name='chosen'),
+    re_path(r'^chooser/$', chooser.choose_modal, name='chooser'),
+    re_path(r'^chooser/(?P<pk>\d+)/(?P<newsitem_pk>\d+)/$', chooser.chosen_modal, name='chosen'),
 ]

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -9,7 +9,13 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.core.models import Page
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail.models import Page
+else: # Support for wagtail <= 4.1
+  from wagtail.core.models import Page
+
 from wagtail.search.backends import get_search_backend
 
 from wagtailnews.conf import paginate

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -13,7 +13,7 @@ from wagtail import VERSION
 from wagtail.admin import messages
 if VERSION >= (3, 0):
   from wagtail.admin.panels import (
-    EditHandler, ObjectList, extract_panel_definitions_from_model_class)
+    ObjectList, extract_panel_definitions_from_model_class)
 else:
   from wagtail.admin.edit_handlers import (
     EditHandler, ObjectList, extract_panel_definitions_from_model_class)

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -14,10 +14,11 @@ from wagtail.admin import messages
 if VERSION >= (3, 0):
   from wagtail.admin.panels import (
     ObjectList, extract_panel_definitions_from_model_class)
+  from wagtail.models import Page
 else:
   from wagtail.admin.edit_handlers import (
     EditHandler, ObjectList, extract_panel_definitions_from_model_class)
-from wagtail.core.models import Page
+  from wagtail.core.models import Page
 
 from .. import signals
 from ..forms import SaveActionSet

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -94,7 +94,7 @@ def create(request, pk):
         form = EditForm(instance=newsitem)
 
     if VERSION >= (3, 0):
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.get_bound_panel(
             instance=newsitem, form=form
         )
     else:
@@ -157,7 +157,7 @@ def edit(request, pk, newsitem_pk):
         do_preview = bool(request.GET.get(OPEN_PREVIEW_PARAM))
 
     if VERSION >= (3, 0):
-        edit_handler = edit_handler.bind_to(
+        edit_handler = edit_handler.get_bound_panel(
             instance=newsitem, form=form
         )
     else:

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -8,7 +8,7 @@ from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail import VERSION
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
-from django.urls import reverse
+from django.urls import reverse, re_path
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.search import SearchArea
@@ -17,7 +17,7 @@ from .permissions import user_can_edit_news
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^news/', include(urls)),
+        re_path(r'^news/', include(urls)),
     ]
 
 

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -6,7 +6,12 @@ from django.urls import reverse, re_path
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.search import SearchArea
-from wagtail.core import hooks
+
+import wagtail
+if wagtail.VERSION >= (4, 2):
+  from wagtail import hooks
+else: # Support for wagtail <= 4.1
+  from wagtail.core import hooks
 
 from . import urls
 from .menu import NewsMenuItem

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -4,7 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.search import SearchArea
 from wagtail.core import hooks
 

--- a/wagtailnews/widgets.py
+++ b/wagtailnews/widgets.py
@@ -1,7 +1,7 @@
 import json
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.widgets import AdminChooser
 
 


### PR DESCRIPTION
Bring wagtailnews up par with Wagtail 3 and 4 and Django >= 3.2. The version compatibilities are taken from here: https://docs.wagtail.org/en/stable/releases/upgrading.html

This PR will fix all the deprecation warnings and is tested to work with Django 3.2 and higher. The admin layout is a little off, mainly the action menu in the bottom, but the library works and does not give errors. Future work is required to bring the class based views to wagtailnews admin and thus achieve similar look with the rest of the Wagtail.

This PR removes support for Wagtail < 3 but the wagtailnews 2.x version should be upkept for that.

This PR does not contain any new features.